### PR TITLE
Fix watchGroup bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# upcoming
+
+* BUGFIX: allow to constantly update hours and minutes in `moment-select`. `$watchGroup` didn't seem to return correct values, altough it was triggered correctly.
+
 # 8.0.2
 
 * BUGFIX: make `disable` attribute passthrough single-choice-input into the radio and select inputs

--- a/src/scripts/moment-select/directives.js
+++ b/src/scripts/moment-select/directives.js
@@ -61,8 +61,8 @@
                         var cast = (scope.useDuration) ? moment.duration : moment;
 
                         scope.$watchGroup(['hours', 'minutes'], function (newValues) {
-                            var hours = newValues[0];
-                            var minutes = newValues[1];
+                            var hours = scope.hours;
+                            var minutes = scope.minutes;
                             var timeObject = {};
 
                             if (angular.isDefined(hours)) {
@@ -74,7 +74,7 @@
                             scope.model = cast(timeObject);
                         });
 
-                        var deregisterModelWatch = scope.$watch('model', function (value) {
+                        scope.$watch('model', function (value) {
                             if (angular.isDefined(scope.model)) {
                                 value = cast(scope.model);
                                 var timeObject = {};
@@ -88,7 +88,6 @@
                                     timeObject.minutes = value.get(minutes);
                                 }
                                 angular.extend(scope, timeObject);
-                                deregisterModelWatch();
                             }
                         });
                     };

--- a/tests/inputFieldsSpec.js
+++ b/tests/inputFieldsSpec.js
@@ -471,6 +471,23 @@
                 });
             });
 
+            it('should watch the model and set hour and minute accordingly', function () {
+                 $scope.duration = '01:30:00';
+                 template = '<div aif-moment-select model="duration" use-duration="true"></div>';
+
+                 compiledTemplate = compile(template);
+
+                 $rootScope.$digest();
+
+                 var isolated = compiledTemplate.isolateScope();
+
+                 $scope.duration = '00:00:00';
+
+                 $rootScope.$digest();
+                 expect(isolated.hours).toBe(0);
+                 expect(isolated.minutes).toBe(0);
+             });
+
             describe('should have hour choices ', function () {
                 it('that default to 0 .. 24', function () {
 


### PR DESCRIPTION
There seems to be a bug with `$watchGroup` not returning the correct `newValues` array. Not sure why though. This seems to fix the infinite `$digest` loop caused otherwise.